### PR TITLE
Fix race condition when launching websockify.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: "Prepare workflow environment variables"
           command: |
-            echo 'export BRANCH="$CIRCLE_BRANCH"' >> $BASH_ENV
+            echo 'export BRANCH="${CIRCLE_BRANCH//\//-}"' >> $BASH_ENV
             cat $BASH_ENV
             source $BASH_ENV
             echo "Workflow environment variables:"
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: "Save Docker Images in Cache"
           command: |  
-            export VERSION=$CIRCLE_BRANCH
+            export VERSION=${CIRCLE_BRANCH//\//-}
             echo $NAMESPACE/base:$VERSION-$BUILD_DATE 
             echo $NAMESPACE/node-base:$VERSION-$BUILD_DATE 
             echo $NAMESPACE/hub:$VERSION-$BUILD_DATE 
@@ -98,7 +98,7 @@ jobs:
           no_output_timeout: 2m
           command: |
             export USE_RANDOM_USER=false
-            export BRANCH=$CIRCLE_BRANCH
+            export BRANCH=${CIRCLE_BRANCH//\//-}
             USE_RANDOM_USER_ID=${USE_RANDOM_USER} NAMESPACE=${NAMESPACE} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} SKIP_BUILD=true make test_multi_arch
 
   deploy-multi-arch:

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -94,6 +94,7 @@ RUN apt-get -qqy update \
 ########################################
 # Download https://github.com/novnc/noVNC dated 2021-03-30 commit 84f102d6a9ffaf3972693d59bad5c6fddb6d7fb0
 # Download https://github.com/novnc/websockify dated 2021-03-22 commit c5d365dd1dbfee89881f1c1c02a2ac64838d645f
+# Install procps as noVNC's launch.sh depends on it to launch websockify properly
 ENV NOVNC_SHA="84f102d6a9ffaf3972693d59bad5c6fddb6d7fb0" \
     WEBSOCKIFY_SHA="c5d365dd1dbfee89881f1c1c02a2ac64838d645f"
 RUN  wget -nv -O noVNC.zip \
@@ -107,7 +108,11 @@ RUN  wget -nv -O noVNC.zip \
   && unzip -x websockify.zip \
   && rm websockify.zip \
   && rm -rf websockify-${WEBSOCKIFY_SHA}/tests \
-  && mv websockify-${WEBSOCKIFY_SHA} /opt/bin/noVNC/utils/websockify
+  && mv websockify-${WEBSOCKIFY_SHA} /opt/bin/noVNC/utils/websockify \
+  && apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install procps \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get -qqy clean
 
 #=========================================================================================================================================
 # Run this command for executable file permissions for /dev/shm when this is a "child" container running in Docker Desktop and WSL2 distro


### PR DESCRIPTION
### Description
Fix for the race condition thoroughly investigated in issue #18 
Summary of issue #18: noVNC's launch.sh invokes `ps`. Without it, it exits prematurely, thus ruining websockify's stdout and stderr file descriptors. Depending on how fast websockify starts up, this may or may not prevent it from working.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.