### PR TITLE
Update README.md with docker-compose seleniarm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,46 @@ To build for armv7l/armhf, replace PLATFORMS environment variable with `linux/ar
 $ NAME=local-seleniarm VERSION=4.5.0 BUILD_DATE=$(date '+%Y%m%d') PLATFORMS=linux/arm/v7 BUILD_ARGS=--load make standalone_chromium_multi
 ```
 
+Docker compose for hub and node using seleniarm docker container images,
+
+**docker-compose-v3-latest-channel.yml:**
+
+```bash
+# To execute this docker-compose yml file use `docker-compose -f docker-compose-v3-beta-channel.yml up`
+# Add the `-d` flag at the end for detached execution
+# To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-v3-beta-channel.yml down`
+version: "3"
+services:
+  chrome:
+    image: seleniarm/node-chromium:latest
+    shm_size: 2gb
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+
+  firefox:
+    image: seleniarm/node-firefox:latest
+    shm_size: 2gb
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+
+  selenium-hub:
+    image: seleniarm/hub:latest
+    container_name: selenium-hub
+    ports:
+      - "4442:4442"
+      - "4443:4443"
+      - "4444:4444"
+
+```
+
 ----
 # -- The official documentation from seleniumHQ begins here --
 ----


### PR DESCRIPTION
### Description
- Add missing hub and node seleniarm docker-compose example
- Use version 3 docker compose
- Use latest image tag


### Motivation and Context
The seleniarm documentation was missing information on the docker compose for hub and node. Anyone who is new will be facing hard time to understand how to create a docker compose for seleniarm docker container images. I myself, struggled for some time and hope this PR commit will help others using arm64 M1 Mac.

### Types of changes
- [x] Documentation example improvement

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change to README.md improves the documentation.
- [x] I have updated the documentation accordingly.
